### PR TITLE
Adjust the path priority of the emulator folder

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -392,20 +392,20 @@ Add the following lines to your `$HOME/.bash_profile` config file:
 
 ```
 export ANDROID_HOME=$HOME/Library/Android/sdk
+export PATH=$PATH:$ANDROID_HOME/emulator
 export PATH=$PATH:$ANDROID_HOME/tools
 export PATH=$PATH:$ANDROID_HOME/tools/bin
 export PATH=$PATH:$ANDROID_HOME/platform-tools
-export PATH=$PATH:$ANDROID_HOME/emulator
 ```
 
 <block class="native linux android" />
 
 ```
 export ANDROID_HOME=$HOME/Android/Sdk
+export PATH=$PATH:$ANDROID_HOME/emulator
 export PATH=$PATH:$ANDROID_HOME/tools
 export PATH=$PATH:$ANDROID_HOME/tools/bin
 export PATH=$PATH:$ANDROID_HOME/platform-tools
-export PATH=$PATH:$ANDROID_HOME/emulator
 ```
 
 <block class="native mac linux android" />


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

Emulators is located in emulators folder not tools folder in more recent versions.
> As of this release, the Android Emulator will be released separately from the SDK Tools. This release contains a variety of performance improvements, new features, and bug fixes.
>
>  [by Emulator release notes (25.3.0 (March 2017)) | Android developer](https://developer.android.com/studio/releases/emulator)

**However tools folder has high priority than emulator folder**. it makes **run the previous version of the emulator command** in the tools folder which **throws error "PANIC: ..."**.

To fix it, adjust priority of emulator folder be high than tools folder.

Sum up,
- `${ANDROID_PATH}/tools/emulator` is not working
- `${ANDROID_PATH}/emulator/emulator` is working

Following references are related question about this issue.
- [Android Emulator Error Message: “PANIC: Missing emulator engine program for 'x86' CPUS.”](https://stackoverflow.com/questions/26483370/android-emulator-error-message-panic-missing-emulator-engine-program-for-x86)
- [ionic cordova run android results in PANIC: Missing emulator engine program for 'x86' CPU](https://stackoverflow.com/questions/49601521/ionic-cordova-run-android-results-in-panic-missing-emulator-engine-program-for)
- [Emulator: PANIC: Missing emulator engine program for 'x86' CPU. on Windows10](https://stackoverflow.com/questions/51674400/emulator-panic-missing-emulator-engine-program-for-x86-cpu-on-windows10)